### PR TITLE
GC4-2: Add multiplayer support

### DIFF
--- a/controller_input/ps3_controller_handler.gd
+++ b/controller_input/ps3_controller_handler.gd
@@ -1,0 +1,37 @@
+class_name PS3ControllerHandler
+
+
+func update_input(
+	input_map: Dictionary[String, float],
+	event: InputEvent,
+	device: int,
+	dead_zone: float = 0.0) -> void:
+	if event.device != device:
+		return
+	for action in input_map:
+		if event.is_action(action):
+			if event is InputEventJoypadMotion:
+				var action_strength: float = abs(event.axis_value)
+				if action == "left":
+					input_map["left"] = 0.0
+					input_map["right"] = 0.0
+					if action_strength <= dead_zone:
+						return
+					elif event.axis_value >= 0:
+						input_map["right"] = action_strength
+					else:
+						input_map["left"] = action_strength
+				elif action == "up":
+					input_map["up"] = 0.0
+					input_map["down"] = 0.0
+					if action_strength <= dead_zone:
+						return
+					elif event.axis_value >= 0:
+						input_map["down"] = action_strength
+					else:
+						input_map["up"] = action_strength
+				else:
+					input_map[action] = action_strength
+			else:
+				input_map[action] = 1.0
+			return

--- a/controller_input/ps3_controller_handler.gd.uid
+++ b/controller_input/ps3_controller_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://djqpppcjllj0i

--- a/controller_input/retro_bit_controller_handler.gd
+++ b/controller_input/retro_bit_controller_handler.gd
@@ -1,0 +1,30 @@
+class_name RetroBitControllerHandler
+
+
+func update_input(
+	input_map: Dictionary[String, float],
+	event: InputEvent,
+	device: int,
+	dead_zone: float = 0.0) -> void:
+		for action in input_map:
+			if event.is_action(action):
+				if event is InputEventJoypadMotion:
+					var action_strength: float = abs(event.axis_value)
+					if action == "left":
+						input_map["left"] = 0.0
+						input_map["right"] = 0.0
+						if action_strength <= dead_zone:
+							return
+						elif event.axis_value >= 0:
+							input_map["right"] = action_strength
+						else:
+							input_map["left"] = action_strength
+					elif action == "up":
+						input_map["up"] = action_strength
+					elif action == "down":
+						input_map["down"] = action_strength
+					else:
+						input_map[action] = action_strength
+				else:
+					input_map[action] = 1.0
+				return

--- a/controller_input/retro_bit_controller_handler.gd.uid
+++ b/controller_input/retro_bit_controller_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://d1ji5iwxk4yl5

--- a/controllers/input_controller.gd
+++ b/controllers/input_controller.gd
@@ -1,6 +1,9 @@
 class_name InputController extends Node
 
-@export_range(0, 1) var controller_deadzone: float = 0.2
+@export_range(0, 1) var controller_dead_zone: float = 0.2
+
+var retro_bit_controller_handler: RetroBitControllerHandler = RetroBitControllerHandler.new()
+var ps3_controller_handler: PS3ControllerHandler = PS3ControllerHandler.new()
 
 var input_map: Dictionary[String, float] = {
 	"up": 0.0,
@@ -20,37 +23,17 @@ func get_direction() -> Vector2:
 
 
 # Run on input
-func update_input(event: InputEvent) -> void:
-	for action in input_map:
-		if event.is_action(action):
-			if event is InputEventJoypadMotion:
-				var action_strength: float = abs(event.axis_value)
-				if action == "left":
-					input_map["left"] = 0.0
-					input_map["right"] = 0.0
-					if action_strength <= controller_deadzone:
-						return
-					elif event.axis_value >= 0:
-						input_map["right"] = action_strength
-					else:
-						input_map["left"] = action_strength
-				elif action == "up":
-					input_map["up"] = 0.0
-					input_map["down"] = 0.0
-					if action_strength <= controller_deadzone:
-						return
-					elif event.axis_value >= 0:
-						input_map["down"] = action_strength
-					else:
-						input_map["up"] = action_strength
-				else:
-					input_map[action] = action_strength
-			else:
-				input_map[action] = 1.0
-			return
+func update_input(event: InputEvent, device: int) -> void:
+	if event.device != device:
+		return
+	var device_name: String = Input.get_joy_name(device)
+	ps3_controller_handler.update_input(input_map, event, device, controller_dead_zone)
+
 
 # Run on unhandled_input
-func update_keyboard_input(event: InputEvent) -> void:
+func update_keyboard_input(event: InputEvent, device: int) -> void:
+	if event.device != device:
+		return
 	for action in input_map:
 		if event.is_action(action):
 			if event.is_pressed():

--- a/controllers/input_controller.gd
+++ b/controllers/input_controller.gd
@@ -1,32 +1,60 @@
 class_name InputController extends Node
 
-var input_map: Dictionary[String, bool] = {
-	"up": false,
-	"down": false,
-	"left": false,
-	"right": false
+@export_range(0, 1) var controller_deadzone: float = 0.2
+
+var input_map: Dictionary[String, float] = {
+	"up": 0.0,
+	"down": 0.0,
+	"left": 0.0,
+	"right": 0.0
 }
 
 
 func get_direction() -> Vector2:
-	var direction: Vector2 = Vector2.ZERO
-	if input_map["up"]:
-		direction += Vector2.UP
-	if input_map["down"]:
-		direction += Vector2.DOWN
-	if input_map["left"]:
-		direction += Vector2.LEFT
-	if input_map["right"]:
-		direction += Vector2.RIGHT
-	return direction.normalized()
+	var direction: Vector2 = Vector2(
+		input_map["right"] - input_map["left"],
+		input_map["down"] - input_map["up"]
+	)
+	var amount: float = min(direction.length(), 1.0)
+	return direction.normalized() * amount
 
 
-# Run on unhandled_input
+# Run on input
 func update_input(event: InputEvent) -> void:
 	for action in input_map:
 		if event.is_action(action):
+			if event is InputEventJoypadMotion:
+				var action_strength: float = abs(event.axis_value)
+				if action == "left":
+					input_map["left"] = 0.0
+					input_map["right"] = 0.0
+					if action_strength <= controller_deadzone:
+						return
+					elif event.axis_value >= 0:
+						input_map["right"] = action_strength
+					else:
+						input_map["left"] = action_strength
+				elif action == "up":
+					input_map["up"] = 0.0
+					input_map["down"] = 0.0
+					if action_strength <= controller_deadzone:
+						return
+					elif event.axis_value >= 0:
+						input_map["down"] = action_strength
+					else:
+						input_map["up"] = action_strength
+				else:
+					input_map[action] = action_strength
+			else:
+				input_map[action] = 1.0
+			return
+
+# Run on unhandled_input
+func update_keyboard_input(event: InputEvent) -> void:
+	for action in input_map:
+		if event.is_action(action):
 			if event.is_pressed():
-				input_map[action] = true
+				input_map[action] = 1.0
 			elif event.is_released():
-				input_map[action] = false
+				input_map[action] = 0.0
 			return

--- a/controllers/input_controller.gd
+++ b/controllers/input_controller.gd
@@ -31,8 +31,9 @@ func update_input(event: InputEvent, device: int) -> void:
 
 # Run on unhandled_input
 func update_keyboard_input(event: InputEvent, device: int, keys: Dictionary) -> void:
-	if event is InputEventKey and !keys.get(event.as_text_keycode(), false):
-		return
+	if keys.size() != 0:
+		if event is InputEventKey and !keys.get(event.as_text_keycode(), false):
+			return
 	for action in input_map:
 		if event.is_action(action):
 			if event.is_pressed():

--- a/controllers/input_controller.gd
+++ b/controllers/input_controller.gd
@@ -26,13 +26,12 @@ func get_direction() -> Vector2:
 func update_input(event: InputEvent, device: int) -> void:
 	if event.device != device:
 		return
-	var device_name: String = Input.get_joy_name(device)
 	ps3_controller_handler.update_input(input_map, event, device, controller_dead_zone)
 
 
 # Run on unhandled_input
-func update_keyboard_input(event: InputEvent, device: int) -> void:
-	if event.device != device:
+func update_keyboard_input(event: InputEvent, device: int, keys: Dictionary) -> void:
+	if event is InputEventKey and !keys.get(event.as_text_keycode(), false):
 		return
 	for action in input_map:
 		if event.is_action(action):

--- a/controllers/input_controller.tscn9693733398.tmp
+++ b/controllers/input_controller.tscn9693733398.tmp
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dhqthycfevgqo"]
+
+[ext_resource type="Script" uid="uid://pjv7g652o4fw" path="res://controllers/input_controller.gd" id="1_6j56o"]
+
+[node name="InputController" type="Node"]
+script = ExtResource("1_6j56o")

--- a/multiplayer.gd
+++ b/multiplayer.gd
@@ -1,0 +1,22 @@
+class_name Multiplayer extends Node2D
+
+@onready var players: Node = $Players
+
+
+func _ready() -> void:
+	var connected_controllers: Array[int] = Input.get_connected_joypads()
+	print(connected_controllers)
+	var i: int = 0
+	if connected_controllers.size() > 0:
+		for player in players.get_children():
+			if player is Player:
+				player.set_device(connected_controllers[i])
+				i += 1
+				if i >= connected_controllers.size():
+					return
+	else:
+		for player in players.get_children():
+			if player is Player:
+				player.set_device(i)
+				return
+		

--- a/multiplayer.gd
+++ b/multiplayer.gd
@@ -2,21 +2,16 @@ class_name Multiplayer extends Node2D
 
 @onready var players: Node = $Players
 
+var player_keys: Dictionary = {
+	0: {"Up": true, "Left": true, "Down": true, "Right": true},
+	1: {"W": true, "A": true, "S": true, "D": true}
+}
+
 
 func _ready() -> void:
-	var connected_controllers: Array[int] = Input.get_connected_joypads()
-	print(connected_controllers)
 	var i: int = 0
-	if connected_controllers.size() > 0:
-		for player in players.get_children():
-			if player is Player:
-				player.set_device(connected_controllers[i])
-				i += 1
-				if i >= connected_controllers.size():
-					return
-	else:
-		for player in players.get_children():
-			if player is Player:
-				player.set_device(i)
-				return
-		
+	for player in players.get_children():
+		if player is Player:
+			player.set_device(i)
+			player.set_keys(player_keys[i])
+			i += 1

--- a/multiplayer.gd.uid
+++ b/multiplayer.gd.uid
@@ -1,0 +1,1 @@
+uid://dnpa3x5jcieyx

--- a/multiplayer.tscn
+++ b/multiplayer.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3 uid="uid://cygvd08neps6x"]
+
+[ext_resource type="PackedScene" uid="uid://c7w7th8hmqmmy" path="res://player.tscn" id="1_o4y1c"]
+[ext_resource type="Script" uid="uid://dnpa3x5jcieyx" path="res://multiplayer.gd" id="1_wktud"]
+
+[node name="Multiplayer" type="Node2D"]
+script = ExtResource("1_wktud")
+
+[node name="Players" type="Node" parent="."]
+
+[node name="Player" parent="Players" instance=ExtResource("1_o4y1c")]
+
+[node name="Player2" parent="Players" instance=ExtResource("1_o4y1c")]
+
+[node name="Camera2D" type="Camera2D" parent="."]

--- a/player.gd
+++ b/player.gd
@@ -5,6 +5,10 @@ class_name Player extends RigidBody2D
 
 
 func _unhandled_key_input(event: InputEvent) -> void:
+	input_controller.update_keyboard_input(event)
+
+
+func _input(event: InputEvent) -> void:
 	input_controller.update_input(event)
 
 

--- a/player.gd
+++ b/player.gd
@@ -4,22 +4,25 @@ class_name Player extends RigidBody2D
 @onready var move_controller: MoveController = $MoveController
 
 
+var player_keys: Dictionary = {}
 var device: int = -1
+
+
+func set_keys(keys: Dictionary) -> void:
+	player_keys = keys
 
 
 func set_device(device: int) -> void:
 	self.device = device
-	print(self)
-	print(device)
 
 
 func _unhandled_key_input(event: InputEvent) -> void:
-	input_controller.update_keyboard_input(event, device)
+	input_controller.update_keyboard_input(event, device, player_keys)
 
 
 func _input(event: InputEvent) -> void:
-	print(device)
-	input_controller.update_input(event, device)
+	return
+	# input_controller.update_input(event, device)
 
 
 func _physics_process(delta: float) -> void:

--- a/player.gd
+++ b/player.gd
@@ -4,12 +4,22 @@ class_name Player extends RigidBody2D
 @onready var move_controller: MoveController = $MoveController
 
 
+var device: int = -1
+
+
+func set_device(device: int) -> void:
+	self.device = device
+	print(self)
+	print(device)
+
+
 func _unhandled_key_input(event: InputEvent) -> void:
-	input_controller.update_keyboard_input(event)
+	input_controller.update_keyboard_input(event, device)
 
 
 func _input(event: InputEvent) -> void:
-	input_controller.update_input(event)
+	print(device)
+	input_controller.update_input(event, device)
 
 
 func _physics_process(delta: float) -> void:

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="20gc4indy500"
-run/main_scene="uid://c7w7th8hmqmmy"
+run/main_scene="uid://cygvd08neps6x"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 
@@ -20,8 +20,9 @@ config/icon="res://icon.svg"
 up={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":-1.0,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":1.0,"script":null)
 ]
 }
 down={
@@ -29,6 +30,7 @@ down={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":1.0,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
 ]
 }
 left={

--- a/project.godot
+++ b/project.godot
@@ -21,24 +21,28 @@ up={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":-1.0,"script":null)
 ]
 }
 down={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":2,"axis_value":1.0,"script":null)
 ]
 }
 left={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
 ]
 }
 right={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
 ]
 }
 


### PR DESCRIPTION
Changes:
- Create multiplayer game mode
- WASD for second player, arrows for first player

Worked on controller support, but annoying to work out.
1. Controller takes over first player (device 0), and keyboard + controller input is used by device 0, so you need two controls for multiplayer.
2. Device name gets wonky for some reason (from plugging in / plugging out different slots?). Tried with ps3 controller and retro bit controller. at first the names were fine (PS3 Controller and DS3 ... Controller), where retro bit was the DS3 controller. But somehow they switched, and I couldn't fix it, so doing custom bindings for different types of controllers doesn't work since the name isn't consistent (obtained from Input.get_joy_name() i think)