### PR TITLE
GC4-10: Create 8 track

### DIFF
--- a/border.gd
+++ b/border.gd
@@ -1,6 +1,8 @@
 class_name Border extends StaticBody2D
 
+@export var create_segment_shapes: bool = false
 @export var collision_polygon: CollisionPolygon2D
+@export var collision_shape: CollisionShape2D
 @export var path: Path2D
 
 @export_group("Visuals")
@@ -10,8 +12,25 @@ class_name Border extends StaticBody2D
 
 func _ready() -> void:
 	var path_points: PackedVector2Array = path.curve.get_baked_points()
-	collision_polygon.polygon = path_points
+	if collision_polygon:
+		collision_polygon.polygon = path_points
 	if line:
 		line.points = path_points
 	if polygon:
 		polygon.polygon = path_points
+	if create_segment_shapes:
+		create_segments()
+
+
+func create_segments() -> void:
+	var points: PackedVector2Array = path.curve.get_baked_points()
+	for i in range(points.size() - 1):
+		var from_point: Vector2 = points[i]
+		var to_point: Vector2 = points[i+1]
+		
+		var segment: CollisionShape2D = CollisionShape2D.new()
+		segment.shape = SegmentShape2D.new()
+		segment.shape.a = from_point
+		segment.shape.b = to_point
+		add_child(segment)
+		

--- a/collision_toggler.gd
+++ b/collision_toggler.gd
@@ -2,6 +2,8 @@ class_name CollisionToggler extends Area2D
 
 
 @export var mask: int = 1
+@export var update_z_layer: bool = false
+@export var z_layer: int = 0
 
 
 func _ready() -> void:
@@ -11,3 +13,5 @@ func _ready() -> void:
 func _on_enter(body: Node2D) -> void:
 	if body is Player:
 		body.collision_mask = mask
+		if update_z_layer:
+			body.z_index = z_layer

--- a/collision_toggler.gd
+++ b/collision_toggler.gd
@@ -1,0 +1,13 @@
+class_name CollisionToggler extends Area2D
+
+
+@export var mask: int = 1
+
+
+func _ready() -> void:
+	body_entered.connect(_on_enter)
+
+
+func _on_enter(body: Node2D) -> void:
+	if body is Player:
+		body.collision_mask = mask

--- a/collision_toggler.gd.uid
+++ b/collision_toggler.gd.uid
@@ -1,0 +1,1 @@
+uid://dgfjwyjgcv743

--- a/collision_toggler.tscn
+++ b/collision_toggler.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://ddit5m5t7myfo"]
+
+[ext_resource type="Script" uid="uid://dgfjwyjgcv743" path="res://collision_toggler.gd" id="1_jrq11"]
+
+[node name="CollisionToggler" type="Area2D"]
+script = ExtResource("1_jrq11")

--- a/collision_toggler.tscn
+++ b/collision_toggler.tscn
@@ -3,4 +3,5 @@
 [ext_resource type="Script" uid="uid://dgfjwyjgcv743" path="res://collision_toggler.gd" id="1_jrq11"]
 
 [node name="CollisionToggler" type="Area2D"]
+collision_layer = 7
 script = ExtResource("1_jrq11")

--- a/stage_menu.gd
+++ b/stage_menu.gd
@@ -3,6 +3,7 @@ class_name StageMenu extends Control
 
 @onready var track_one_button: Button = $GridContainer/TrackOneButton
 @onready var track_two_button: Button = $GridContainer/TrackTwoButton
+@onready var track_three_button: Button = $GridContainer/TrackThreeButton
 @onready var back_button: Button = $GridContainer/BackButton
 @onready var player_count_slider: Slider = $GridContainer/HSlider
 @onready var player_label: Label = $GridContainer/PlayerLabel
@@ -30,6 +31,17 @@ func _ready() -> void:
 			"timer_position": Vector2(128, 30),
 			"header_position": Vector2(0, 450.0),
 			"track_name": "track_2"
+		}
+	))
+	track_two_button.mouse_entered.connect(_on_enter)
+	
+	track_three_button.pressed.connect(start_stage.bind(
+		{
+			"players": player_count_slider.value,
+			"camera_zoom": 0.6,
+			"timer_position": Vector2(0, 400),
+			"header_position": Vector2(0, -500.0),
+			"track_name": "track_3"
 		}
 	))
 	track_two_button.mouse_entered.connect(_on_enter)

--- a/stage_menu.gd
+++ b/stage_menu.gd
@@ -39,7 +39,7 @@ func _ready() -> void:
 		{
 			"players": player_count_slider.value,
 			"camera_zoom": 0.6,
-			"timer_position": Vector2(0, 400),
+			"timer_position": Vector2(0, 465),
 			"header_position": Vector2(0, -500.0),
 			"track_name": "track_3"
 		}

--- a/stage_menu.tscn
+++ b/stage_menu.tscn
@@ -102,6 +102,25 @@ theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_p3jrs")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_p3jrs")
 text = "Squiggly Track"
 
+[node name="TrackThreeButton" type="Button" parent="GridContainer"]
+texture_filter = 1
+layout_mode = 2
+size_flags_horizontal = 6
+size_flags_vertical = 4
+theme_override_font_sizes/font_size = 64
+theme_override_styles/focus = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/disabled_mirrored = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/disabled = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/hover_pressed = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/hover_mirrored = SubResource("StyleBoxEmpty_at0u2")
+theme_override_styles/hover = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/pressed_mirrored = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/pressed = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/normal_mirrored = SubResource("StyleBoxEmpty_p3jrs")
+theme_override_styles/normal = SubResource("StyleBoxEmpty_p3jrs")
+text = "8 Track"
+
 [node name="BackButton" type="Button" parent="GridContainer"]
 texture_filter = 1
 layout_mode = 2

--- a/tracks/track.gd
+++ b/tracks/track.gd
@@ -2,12 +2,14 @@ class_name Track extends Node
 
 @export var spawn: Node2D
 @export var spawn_offset: float = 64 # From top downwards
+@export var spawn_angle: float = 90 # Degrees
 
 
 func spawn_players(players: Node) -> void:
 	if players:
 		var current_spawn_offset: float = spawn_offset
+		var offset_direction: Vector2 = Vector2.RIGHT.rotated(deg_to_rad(spawn_angle))
 		for player in players.get_children():
-			player.global_position = spawn.global_position + (current_spawn_offset * Vector2.DOWN)
-			player.global_rotation = spawn.global_rotation
+			player.global_position = spawn.global_position + (current_spawn_offset * offset_direction)
+			player.global_rotation = -deg_to_rad(spawn_angle)
 			current_spawn_offset += spawn_offset

--- a/tracks/track.gd
+++ b/tracks/track.gd
@@ -3,6 +3,7 @@ class_name Track extends Node
 @export var spawn: Node2D
 @export var spawn_offset: float = 64 # From top downwards
 @export var spawn_angle: float = 90 # Degrees
+@export var player_spawn_angle: float = -90 # Degrees
 
 
 func spawn_players(players: Node) -> void:
@@ -11,5 +12,5 @@ func spawn_players(players: Node) -> void:
 		var offset_direction: Vector2 = Vector2.RIGHT.rotated(deg_to_rad(spawn_angle))
 		for player in players.get_children():
 			player.global_position = spawn.global_position + (current_spawn_offset * offset_direction)
-			player.global_rotation = -deg_to_rad(spawn_angle)
+			player.global_rotation = deg_to_rad(player_spawn_angle)
 			current_spawn_offset += spawn_offset

--- a/tracks/track_3.tscn
+++ b/tracks/track_3.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://bfqjnq2gn1pyo"]
+[gd_scene load_steps=24 format=3 uid="uid://bfqjnq2gn1pyo"]
 
 [ext_resource type="Script" uid="uid://18co37d0fg7c" path="res://tracks/track.gd" id="1_2uduf"]
 [ext_resource type="PackedScene" uid="uid://dvx6q6jrrb2hb" path="res://border.tscn" id="2_tsanx"]
@@ -12,8 +12,6 @@ _data = {
 "points": PackedVector2Array(0, 0, 0, 0, 32, -312, 0, 0, 0, 0, 245, -508, 0, 0, 0, 0, 803, -36, 0, 0, 0, 0, 267, 396, 0, 0, 0, 0, -283, -131)
 }
 point_count = 5
-
-[sub_resource type="SegmentShape2D" id="SegmentShape2D_w7xv1"]
 
 [sub_resource type="Curve2D" id="Curve2D_l2gc0"]
 _data = {
@@ -136,9 +134,6 @@ curve = SubResource("Curve2D_tsanx")
 
 [node name="Line2D" type="Line2D" parent="Right1"]
 z_index = 3
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Right1"]
-shape = SubResource("SegmentShape2D_w7xv1")
 
 [node name="Right2" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
 z_index = 3

--- a/tracks/track_3.tscn
+++ b/tracks/track_3.tscn
@@ -93,6 +93,7 @@ b = Vector2(-5, 109)
 script = ExtResource("1_2uduf")
 spawn = NodePath("Spawn")
 spawn_angle = 40.0
+player_spawn_angle = 220.0
 
 [node name="ColorRect" type="ColorRect" parent="."]
 z_index = -1000
@@ -110,7 +111,7 @@ grow_vertical = 2
 color = Color(0, 0, 0, 1)
 
 [node name="Spawn" type="Node2D" parent="."]
-position = Vector2(411.825, -44.345)
+position = Vector2(425, -84)
 
 [node name="Right1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 5
@@ -181,6 +182,7 @@ build_mode = 1
 curve = SubResource("Curve2D_2fmj2")
 
 [node name="Line2D" type="Line2D" parent="Left4"]
+default_color = Color(1, 1, 1, 0)
 
 [node name="Left6" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
@@ -209,6 +211,7 @@ build_mode = 1
 curve = SubResource("Curve2D_ckjgs")
 
 [node name="Line2D" type="Line2D" parent="Left2"]
+default_color = Color(1, 1, 1, 0)
 
 [node name="Left5" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
@@ -286,3 +289,9 @@ shape = SubResource("SegmentShape2D_2fmj2")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler7"]
 shape = SubResource("SegmentShape2D_nsedx")
+
+[node name="ColorRect2" type="ColorRect" parent="."]
+offset_left = -345.0
+offset_top = 344.0
+offset_right = 321.0
+offset_bottom = 462.0

--- a/tracks/track_3.tscn
+++ b/tracks/track_3.tscn
@@ -1,0 +1,115 @@
+[gd_scene load_steps=11 format=3 uid="uid://bfqjnq2gn1pyo"]
+
+[ext_resource type="Script" uid="uid://18co37d0fg7c" path="res://tracks/track.gd" id="1_2uduf"]
+[ext_resource type="PackedScene" uid="uid://dvx6q6jrrb2hb" path="res://border.tscn" id="2_tsanx"]
+[ext_resource type="PackedScene" uid="uid://d1f7dwnnhrutk" path="res://finish_line.tscn" id="3_6lu36"]
+[ext_resource type="Texture2D" uid="uid://dp6n84sdikk8y" path="res://assets/finish_line_checker.png" id="4_l2gc0"]
+[ext_resource type="PackedScene" uid="uid://d3qag8r5tmx4d" path="res://start_line.tscn" id="5_5tug4"]
+
+[sub_resource type="Curve2D" id="Curve2D_jhe20"]
+_data = {
+"points": PackedVector2Array(0, 0, 320, 0, 384, -320, 0, 0, 0, 0, 704, 0, 320, 0, 0, 0, 384, 320)
+}
+point_count = 3
+
+[sub_resource type="Curve2D" id="Curve2D_2uduf"]
+_data = {
+"points": PackedVector2Array(320, 0, 0, 0, 384, 320, 0, 0, -320, 0, -384, -320)
+}
+point_count = 2
+
+[sub_resource type="Curve2D" id="Curve2D_tsanx"]
+_data = {
+"points": PackedVector2Array(0, 0, 320, 0, 384, -320, 0, 0, 0, 0, 704, 0, 320, 0, 0, 0, 384, 320, 0, 0, 0, 0, 0, 0, 0, 0, -320, 0, -384, -320, 0, 0, 0, 0, -704, 0, -320, 0, 0, 0, -384, 320, 0, 0, 0, 0, 384, -320)
+}
+point_count = 8
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_jhe20"]
+size = Vector2(128, 192)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_cejyx"]
+size = Vector2(128, 192)
+
+[node name="Track3" type="Node" node_paths=PackedStringArray("spawn")]
+script = ExtResource("1_2uduf")
+spawn = NodePath("Spawn")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+z_index = -1000
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -2112.0
+offset_top = -1575.0
+offset_right = 888.0
+offset_bottom = 1425.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
+[node name="Right1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+visible = false
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Right1"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="Right1"]
+curve = SubResource("Curve2D_jhe20")
+
+[node name="Line2D" type="Line2D" parent="Right1"]
+
+[node name="Middle1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Middle1"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="Middle1"]
+curve = SubResource("Curve2D_2uduf")
+
+[node name="Line2D" type="Line2D" parent="Middle1"]
+
+[node name="Spawn" type="Node2D" parent="."]
+position = Vector2(128, -320)
+rotation = -1.5708
+
+[node name="OuterBorder3" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="OuterBorder3"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="OuterBorder3"]
+curve = SubResource("Curve2D_tsanx")
+
+[node name="Line2D" type="Line2D" parent="OuterBorder3"]
+
+[node name="FinishLine" parent="." instance=ExtResource("3_6lu36")]
+position = Vector2(0, -224)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="FinishLine"]
+shape = SubResource("RectangleShape2D_jhe20")
+
+[node name="Sprite2D" type="Sprite2D" parent="FinishLine"]
+texture_filter = 1
+texture_repeat = 2
+texture = ExtResource("4_l2gc0")
+region_enabled = true
+region_rect = Rect2(0, 0, 128, 192)
+
+[node name="Node2D" type="Node2D" parent="FinishLine"]
+
+[node name="StartLine" parent="." instance=ExtResource("5_5tug4")]
+position = Vector2(-128, -224)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StartLine"]
+shape = SubResource("RectangleShape2D_cejyx")

--- a/tracks/track_3.tscn
+++ b/tracks/track_3.tscn
@@ -1,28 +1,59 @@
-[gd_scene load_steps=11 format=3 uid="uid://bfqjnq2gn1pyo"]
+[gd_scene load_steps=24 format=3 uid="uid://bfqjnq2gn1pyo"]
 
 [ext_resource type="Script" uid="uid://18co37d0fg7c" path="res://tracks/track.gd" id="1_2uduf"]
 [ext_resource type="PackedScene" uid="uid://dvx6q6jrrb2hb" path="res://border.tscn" id="2_tsanx"]
 [ext_resource type="PackedScene" uid="uid://d1f7dwnnhrutk" path="res://finish_line.tscn" id="3_6lu36"]
 [ext_resource type="Texture2D" uid="uid://dp6n84sdikk8y" path="res://assets/finish_line_checker.png" id="4_l2gc0"]
 [ext_resource type="PackedScene" uid="uid://d3qag8r5tmx4d" path="res://start_line.tscn" id="5_5tug4"]
-
-[sub_resource type="Curve2D" id="Curve2D_jhe20"]
-_data = {
-"points": PackedVector2Array(0, 0, 320, 0, 384, -320, 0, 0, 0, 0, 704, 0, 320, 0, 0, 0, 384, 320)
-}
-point_count = 3
-
-[sub_resource type="Curve2D" id="Curve2D_2uduf"]
-_data = {
-"points": PackedVector2Array(320, 0, 0, 0, 384, 320, 0, 0, -320, 0, -384, -320)
-}
-point_count = 2
+[ext_resource type="PackedScene" uid="uid://ddit5m5t7myfo" path="res://collision_toggler.tscn" id="6_tsanx"]
 
 [sub_resource type="Curve2D" id="Curve2D_tsanx"]
 _data = {
-"points": PackedVector2Array(0, 0, 320, 0, 384, -320, 0, 0, 0, 0, 704, 0, 320, 0, 0, 0, 384, 320, 0, 0, 0, 0, 0, 0, 0, 0, -320, 0, -384, -320, 0, 0, 0, 0, -704, 0, -320, 0, 0, 0, -384, 320, 0, 0, 0, 0, 384, -320)
+"points": PackedVector2Array(0, 0, 0, 0, 88, -254, 0, 0, 0, 0, 232, -403, 0, 0, 0, 0, 635, -42, 0, 0, 0, 0, 267, 323, 0, 0, 0, 0, -241, -99)
 }
-point_count = 8
+point_count = 5
+
+[sub_resource type="Curve2D" id="Curve2D_l2gc0"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, 219, -134, 0, 0, 0, 0, 260, -169, 0, 0, 0, 0, 414, -44, 0, 0, 0, 0, 264, 102, 0, 0, 0, 0, -131, -243)
+}
+point_count = 5
+
+[sub_resource type="Curve2D" id="Curve2D_5tug4"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -131, -243, 0, 0, 0, 0, -330, -417, 0, 0, 0, 0, -715, -1, 0, 0, 0, 0, -310, 332, 0, 0, 0, 0, -18, 86)
+}
+point_count = 5
+
+[sub_resource type="Curve2D" id="Curve2D_a6y52"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -241, -99, 0, 0, 0, 0, -320, -159, 0, 0, 0, 0, -486, -11, 0, 0, 0, 0, -322, 123, 0, 0, 0, 0, -152, -25)
+}
+point_count = 5
+
+[sub_resource type="Curve2D" id="Curve2D_2fmj2"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -152, -25, 0, 0, 0, 0, -22, -148)
+}
+point_count = 2
+
+[sub_resource type="Curve2D" id="Curve2D_nsedx"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -22, -148, 0, 0, 0, 0, 88, -254)
+}
+point_count = 2
+
+[sub_resource type="Curve2D" id="Curve2D_ckjgs"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, -18, 86, 0, 0, 0, 0, 112, -31)
+}
+point_count = 2
+
+[sub_resource type="Curve2D" id="Curve2D_18awt"]
+_data = {
+"points": PackedVector2Array(0, 0, 0, 0, 112, -31, 0, 0, 0, 0, 219, -134)
+}
+point_count = 2
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jhe20"]
 size = Vector2(128, 192)
@@ -30,9 +61,38 @@ size = Vector2(128, 192)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_cejyx"]
 size = Vector2(128, 192)
 
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_tsanx"]
+a = Vector2(-19, -170)
+b = Vector2(-183, -20)
+
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_6lu36"]
+a = Vector2(-96, -243)
+b = Vector2(-251, -76)
+
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_l2gc0"]
+a = Vector2(-237, 27)
+b = Vector2(-64, 166)
+
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_5tug4"]
+a = Vector2(-467, 275)
+b = Vector2(-360, 57)
+
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_a6y52"]
+a = Vector2(-13, -169)
+b = Vector2(135, -37)
+
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_2fmj2"]
+a = Vector2(57, -241)
+b = Vector2(205, -101)
+
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_nsedx"]
+a = Vector2(138, -21)
+b = Vector2(-5, 109)
+
 [node name="Track3" type="Node" node_paths=PackedStringArray("spawn")]
 script = ExtResource("1_2uduf")
 spawn = NodePath("Spawn")
+spawn_angle = 40.0
 
 [node name="ColorRect" type="ColorRect" parent="."]
 z_index = -1000
@@ -49,8 +109,11 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0, 0, 0, 1)
 
+[node name="Spawn" type="Node2D" parent="."]
+position = Vector2(411.825, -44.345)
+
 [node name="Right1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
-visible = false
+collision_layer = 5
 collision_polygon = NodePath("CollisionPolygon2D")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
@@ -59,42 +122,111 @@ line = NodePath("Line2D")
 build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Right1"]
-curve = SubResource("Curve2D_jhe20")
+curve = SubResource("Curve2D_tsanx")
 
 [node name="Line2D" type="Line2D" parent="Right1"]
 
-[node name="Middle1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Right2" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_layer = 5
 collision_polygon = NodePath("CollisionPolygon2D")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Middle1"]
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Right2"]
 build_mode = 1
 
-[node name="Path2D" type="Path2D" parent="Middle1"]
-curve = SubResource("Curve2D_2uduf")
+[node name="Path2D" type="Path2D" parent="Right2"]
+curve = SubResource("Curve2D_l2gc0")
 
-[node name="Line2D" type="Line2D" parent="Middle1"]
+[node name="Line2D" type="Line2D" parent="Right2"]
 
-[node name="Spawn" type="Node2D" parent="."]
-position = Vector2(128, -320)
-rotation = -1.5708
-
-[node name="OuterBorder3" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Left1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_layer = 6
 collision_polygon = NodePath("CollisionPolygon2D")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="OuterBorder3"]
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left1"]
 build_mode = 1
 
-[node name="Path2D" type="Path2D" parent="OuterBorder3"]
-curve = SubResource("Curve2D_tsanx")
+[node name="Path2D" type="Path2D" parent="Left1"]
+curve = SubResource("Curve2D_5tug4")
 
-[node name="Line2D" type="Line2D" parent="OuterBorder3"]
+[node name="Line2D" type="Line2D" parent="Left1"]
+
+[node name="Left3" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_layer = 6
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left3"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="Left3"]
+curve = SubResource("Curve2D_a6y52")
+
+[node name="Line2D" type="Line2D" parent="Left3"]
+
+[node name="Left4" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_layer = 6
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left4"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="Left4"]
+curve = SubResource("Curve2D_2fmj2")
+
+[node name="Line2D" type="Line2D" parent="Left4"]
+
+[node name="Left6" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_layer = 6
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left6"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="Left6"]
+curve = SubResource("Curve2D_nsedx")
+
+[node name="Line2D" type="Line2D" parent="Left6"]
+
+[node name="Left2" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_layer = 6
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left2"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="Left2"]
+curve = SubResource("Curve2D_ckjgs")
+
+[node name="Line2D" type="Line2D" parent="Left2"]
+
+[node name="Left5" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+collision_layer = 6
+collision_polygon = NodePath("CollisionPolygon2D")
+path = NodePath("Path2D")
+line = NodePath("Line2D")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left5"]
+build_mode = 1
+
+[node name="Path2D" type="Path2D" parent="Left5"]
+curve = SubResource("Curve2D_18awt")
+
+[node name="Line2D" type="Line2D" parent="Left5"]
 
 [node name="FinishLine" parent="." instance=ExtResource("3_6lu36")]
-position = Vector2(0, -224)
+position = Vector2(406.24, 73.02)
+rotation = 2.33001
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="FinishLine"]
 shape = SubResource("RectangleShape2D_jhe20")
@@ -109,7 +241,48 @@ region_rect = Rect2(0, 0, 128, 192)
 [node name="Node2D" type="Node2D" parent="FinishLine"]
 
 [node name="StartLine" parent="." instance=ExtResource("5_5tug4")]
-position = Vector2(-128, -224)
+position = Vector2(319.82, 166.895)
+rotation = 2.33001
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StartLine"]
 shape = SubResource("RectangleShape2D_cejyx")
+
+[node name="CollisionToggler" parent="." instance=ExtResource("6_tsanx")]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler"]
+shape = SubResource("SegmentShape2D_tsanx")
+
+[node name="CollisionToggler2" parent="." instance=ExtResource("6_tsanx")]
+mask = 3
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler2"]
+shape = SubResource("SegmentShape2D_6lu36")
+
+[node name="CollisionToggler3" parent="." instance=ExtResource("6_tsanx")]
+mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler3"]
+shape = SubResource("SegmentShape2D_l2gc0")
+
+[node name="CollisionToggler4" parent="." instance=ExtResource("6_tsanx")]
+mask = 3
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler4"]
+shape = SubResource("SegmentShape2D_5tug4")
+
+[node name="CollisionToggler5" parent="." instance=ExtResource("6_tsanx")]
+mask = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler5"]
+shape = SubResource("SegmentShape2D_a6y52")
+
+[node name="CollisionToggler6" parent="." instance=ExtResource("6_tsanx")]
+mask = 3
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler6"]
+shape = SubResource("SegmentShape2D_2fmj2")
+
+[node name="CollisionToggler7" parent="." instance=ExtResource("6_tsanx")]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler7"]
+shape = SubResource("SegmentShape2D_nsedx")

--- a/tracks/track_3.tscn
+++ b/tracks/track_3.tscn
@@ -9,7 +9,7 @@
 
 [sub_resource type="Curve2D" id="Curve2D_tsanx"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, 88, -254, 0, 0, 0, 0, 232, -403, 0, 0, 0, 0, 635, -42, 0, 0, 0, 0, 267, 323, 0, 0, 0, 0, -241, -99)
+"points": PackedVector2Array(0, 0, 0, 0, 32, -312, 0, 0, 0, 0, 245, -508, 0, 0, 0, 0, 803, -36, 0, 0, 0, 0, 267, 396, 0, 0, 0, 0, -283, -131)
 }
 point_count = 5
 
@@ -17,79 +17,79 @@ point_count = 5
 
 [sub_resource type="Curve2D" id="Curve2D_l2gc0"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, 219, -134, 0, 0, 0, 0, 260, -169, 0, 0, 0, 0, 414, -44, 0, 0, 0, 0, 264, 102, 0, 0, 0, 0, -131, -243)
+"points": PackedVector2Array(0, 0, 0, 0, 219, -134, 0, 0, 0, 0, 260, -169, 0, 0, 0, 0, 394, -52, 0, 0, 0, 0, 300, 45, 0, 0, 0, 0, -119, -321)
 }
 point_count = 5
 
 [sub_resource type="Curve2D" id="Curve2D_5tug4"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, -131, -243, 0, 0, 0, 0, -330, -417, 0, 0, 0, 0, -715, -1, 0, 0, 0, 0, -310, 332, 0, 0, 0, 0, -18, 86)
+"points": PackedVector2Array(0, 0, 0, 0, -119, -321, 0, 0, 0, 0, -335, -500, 0, 0, 0, 0, -836, -3, 0, 0, 0, 0, -310, 390, 0, 0, 0, 0, -37, 104)
 }
 point_count = 5
 
 [sub_resource type="Curve2D" id="Curve2D_a6y52"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, -241, -99, 0, 0, 0, 0, -320, -159, 0, 0, 0, 0, -486, -11, 0, 0, 0, 0, -322, 123, 0, 0, 0, 0, -152, -25)
+"points": PackedVector2Array(0, 0, 0, 0, -283, -131, 0, 0, 0, 0, -320, -159, 0, 0, 0, 0, -434, -43, 0, 0, 0, 0, -323, 39, 0, 0, 0, 0, -227, -85)
 }
 point_count = 5
 
 [sub_resource type="Curve2D" id="Curve2D_2fmj2"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, -152, -25, 0, 0, 0, 0, -22, -148)
+"points": PackedVector2Array(0, 0, 0, 0, -227, -85, 0, 0, 0, 0, -44, -253)
 }
 point_count = 2
 
 [sub_resource type="Curve2D" id="Curve2D_nsedx"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, -22, -148, 0, 0, 0, 0, 88, -254)
+"points": PackedVector2Array(0, 0, 0, 0, -41, -254, 0, 0, 0, 0, 32, -312)
 }
 point_count = 2
 
 [sub_resource type="Curve2D" id="Curve2D_ckjgs"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, -18, 86, 0, 0, 0, 0, 112, -31)
+"points": PackedVector2Array(0, 0, 0, 0, -37, 104, 0, 0, 0, 0, 158, -79)
 }
 point_count = 2
 
 [sub_resource type="Curve2D" id="Curve2D_18awt"]
 _data = {
-"points": PackedVector2Array(0, 0, 0, 0, 112, -31, 0, 0, 0, 0, 219, -134)
+"points": PackedVector2Array(0, 0, 0, 0, 158, -79, 0, 0, 0, 0, 219, -134)
 }
 point_count = 2
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jhe20"]
-size = Vector2(128, 192)
+size = Vector2(128, 285.943)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_cejyx"]
-size = Vector2(128, 192)
+size = Vector2(128, 300)
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_tsanx"]
-a = Vector2(-19, -170)
-b = Vector2(-183, -20)
+a = Vector2(-43, -270)
+b = Vector2(-248, -79)
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_6lu36"]
-a = Vector2(-96, -243)
-b = Vector2(-251, -76)
+a = Vector2(-99, -318)
+b = Vector2(-278, -109)
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_l2gc0"]
-a = Vector2(-237, 27)
-b = Vector2(-64, 166)
+a = Vector2(-257, -71)
+b = Vector2(-32, 120)
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_5tug4"]
-a = Vector2(-467, 275)
-b = Vector2(-360, 57)
+a = Vector2(-215, 337)
+b = Vector2(-334, 10)
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_a6y52"]
-a = Vector2(-13, -169)
-b = Vector2(135, -37)
+a = Vector2(-41, -266)
+b = Vector2(176, -77)
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_2fmj2"]
-a = Vector2(57, -241)
-b = Vector2(205, -101)
+a = Vector2(9, -309)
+b = Vector2(209, -116)
 
 [sub_resource type="SegmentShape2D" id="SegmentShape2D_nsedx"]
-a = Vector2(138, -21)
-b = Vector2(-5, 109)
+a = Vector2(181, -69)
+b = Vector2(-27, 133)
 
 [node name="Track3" type="Node" node_paths=PackedStringArray("spawn")]
 script = ExtResource("1_2uduf")
@@ -99,10 +99,10 @@ player_spawn_angle = 220.0
 
 [node name="ColorRect3" type="ColorRect" parent="."]
 z_index = 1
-offset_left = -27.0
-offset_top = -155.0
-offset_right = 158.0
-offset_bottom = 21.0
+offset_left = -50.0
+offset_top = -272.0
+offset_right = 239.0
+offset_bottom = -8.0
 rotation = 0.750492
 color = Color(0, 0, 0, 1)
 
@@ -228,23 +228,25 @@ curve = SubResource("Curve2D_18awt")
 [node name="Line2D" type="Line2D" parent="Left5"]
 
 [node name="FinishLine" parent="." instance=ExtResource("3_6lu36")]
-position = Vector2(406.24, 73.02)
+position = Vector2(427.375, 63.915)
 rotation = 2.33001
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="FinishLine"]
+position = Vector2(-1.52588e-05, -33.7417)
 shape = SubResource("RectangleShape2D_jhe20")
 
 [node name="Sprite2D" type="Sprite2D" parent="FinishLine"]
 texture_filter = 1
 texture_repeat = 2
+position = Vector2(0, -34.0917)
 texture = ExtResource("4_l2gc0")
 region_enabled = true
-region_rect = Rect2(0, 0, 128, 192)
+region_rect = Rect2(0, 0, 128, 285.943)
 
 [node name="Node2D" type="Node2D" parent="FinishLine"]
 
 [node name="StartLine" parent="." instance=ExtResource("5_5tug4")]
-position = Vector2(319.82, 166.895)
+position = Vector2(348.795, 166.895)
 rotation = 2.33001
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StartLine"]
@@ -297,7 +299,7 @@ z_layer = 2
 shape = SubResource("SegmentShape2D_nsedx")
 
 [node name="ColorRect2" type="ColorRect" parent="."]
-offset_left = -345.0
-offset_top = 344.0
-offset_right = 321.0
-offset_bottom = 462.0
+offset_left = -334.0
+offset_top = 408.0
+offset_right = 332.0
+offset_bottom = 526.0

--- a/tracks/track_3.tscn
+++ b/tracks/track_3.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://bfqjnq2gn1pyo"]
+[gd_scene load_steps=25 format=3 uid="uid://bfqjnq2gn1pyo"]
 
 [ext_resource type="Script" uid="uid://18co37d0fg7c" path="res://tracks/track.gd" id="1_2uduf"]
 [ext_resource type="PackedScene" uid="uid://dvx6q6jrrb2hb" path="res://border.tscn" id="2_tsanx"]
@@ -12,6 +12,8 @@ _data = {
 "points": PackedVector2Array(0, 0, 0, 0, 88, -254, 0, 0, 0, 0, 232, -403, 0, 0, 0, 0, 635, -42, 0, 0, 0, 0, 267, 323, 0, 0, 0, 0, -241, -99)
 }
 point_count = 5
+
+[sub_resource type="SegmentShape2D" id="SegmentShape2D_w7xv1"]
 
 [sub_resource type="Curve2D" id="Curve2D_l2gc0"]
 _data = {
@@ -115,26 +117,25 @@ position = Vector2(425, -84)
 
 [node name="Right1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 5
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Right1"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Right1"]
 curve = SubResource("Curve2D_tsanx")
 
 [node name="Line2D" type="Line2D" parent="Right1"]
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Right1"]
+shape = SubResource("SegmentShape2D_w7xv1")
+
 [node name="Right2" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 5
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Right2"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Right2"]
 curve = SubResource("Curve2D_l2gc0")
@@ -143,12 +144,10 @@ curve = SubResource("Curve2D_l2gc0")
 
 [node name="Left1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left1"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Left1"]
 curve = SubResource("Curve2D_5tug4")
@@ -157,12 +156,10 @@ curve = SubResource("Curve2D_5tug4")
 
 [node name="Left3" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left3"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Left3"]
 curve = SubResource("Curve2D_a6y52")
@@ -171,12 +168,10 @@ curve = SubResource("Curve2D_a6y52")
 
 [node name="Left4" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left4"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Left4"]
 curve = SubResource("Curve2D_2fmj2")
@@ -186,12 +181,10 @@ default_color = Color(1, 1, 1, 0)
 
 [node name="Left6" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left6"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Left6"]
 curve = SubResource("Curve2D_nsedx")
@@ -200,12 +193,10 @@ curve = SubResource("Curve2D_nsedx")
 
 [node name="Left2" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left2"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Left2"]
 curve = SubResource("Curve2D_ckjgs")
@@ -215,12 +206,10 @@ default_color = Color(1, 1, 1, 0)
 
 [node name="Left5" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
 collision_layer = 6
-collision_polygon = NodePath("CollisionPolygon2D")
+create_segment_shapes = true
+collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Left5"]
-build_mode = 1
 
 [node name="Path2D" type="Path2D" parent="Left5"]
 curve = SubResource("Curve2D_18awt")

--- a/tracks/track_3.tscn
+++ b/tracks/track_3.tscn
@@ -97,6 +97,15 @@ spawn = NodePath("Spawn")
 spawn_angle = 40.0
 player_spawn_angle = 220.0
 
+[node name="ColorRect3" type="ColorRect" parent="."]
+z_index = 1
+offset_left = -27.0
+offset_top = -155.0
+offset_right = 158.0
+offset_bottom = 21.0
+rotation = 0.750492
+color = Color(0, 0, 0, 1)
+
 [node name="ColorRect" type="ColorRect" parent="."]
 z_index = -1000
 anchors_preset = 8
@@ -115,10 +124,10 @@ color = Color(0, 0, 0, 1)
 [node name="Spawn" type="Node2D" parent="."]
 position = Vector2(425, -84)
 
-[node name="Right1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Right1" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 5
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -126,14 +135,15 @@ line = NodePath("Line2D")
 curve = SubResource("Curve2D_tsanx")
 
 [node name="Line2D" type="Line2D" parent="Right1"]
+z_index = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Right1"]
 shape = SubResource("SegmentShape2D_w7xv1")
 
-[node name="Right2" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Right2" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 5
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -141,11 +151,12 @@ line = NodePath("Line2D")
 curve = SubResource("Curve2D_l2gc0")
 
 [node name="Line2D" type="Line2D" parent="Right2"]
+z_index = 3
 
-[node name="Left1" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Left1" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 6
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -154,10 +165,10 @@ curve = SubResource("Curve2D_5tug4")
 
 [node name="Line2D" type="Line2D" parent="Left1"]
 
-[node name="Left3" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Left3" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 6
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -166,10 +177,10 @@ curve = SubResource("Curve2D_a6y52")
 
 [node name="Line2D" type="Line2D" parent="Left3"]
 
-[node name="Left4" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Left4" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 6
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -179,10 +190,10 @@ curve = SubResource("Curve2D_2fmj2")
 [node name="Line2D" type="Line2D" parent="Left4"]
 default_color = Color(1, 1, 1, 0)
 
-[node name="Left6" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Left6" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 6
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -191,10 +202,10 @@ curve = SubResource("Curve2D_nsedx")
 
 [node name="Line2D" type="Line2D" parent="Left6"]
 
-[node name="Left2" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Left2" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 6
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -204,10 +215,10 @@ curve = SubResource("Curve2D_ckjgs")
 [node name="Line2D" type="Line2D" parent="Left2"]
 default_color = Color(1, 1, 1, 0)
 
-[node name="Left5" parent="." node_paths=PackedStringArray("collision_polygon", "path", "line") instance=ExtResource("2_tsanx")]
+[node name="Left5" parent="." node_paths=PackedStringArray("path", "line") instance=ExtResource("2_tsanx")]
+z_index = 3
 collision_layer = 6
 create_segment_shapes = true
-collision_polygon = NodePath("")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
 
@@ -240,6 +251,8 @@ rotation = 2.33001
 shape = SubResource("RectangleShape2D_cejyx")
 
 [node name="CollisionToggler" parent="." instance=ExtResource("6_tsanx")]
+update_z_layer = true
+z_layer = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler"]
 shape = SubResource("SegmentShape2D_tsanx")
@@ -252,6 +265,7 @@ shape = SubResource("SegmentShape2D_6lu36")
 
 [node name="CollisionToggler3" parent="." instance=ExtResource("6_tsanx")]
 mask = 2
+update_z_layer = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler3"]
 shape = SubResource("SegmentShape2D_l2gc0")
@@ -264,6 +278,7 @@ shape = SubResource("SegmentShape2D_5tug4")
 
 [node name="CollisionToggler5" parent="." instance=ExtResource("6_tsanx")]
 mask = 2
+update_z_layer = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler5"]
 shape = SubResource("SegmentShape2D_a6y52")
@@ -275,6 +290,8 @@ mask = 3
 shape = SubResource("SegmentShape2D_2fmj2")
 
 [node name="CollisionToggler7" parent="." instance=ExtResource("6_tsanx")]
+update_z_layer = true
+z_layer = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="CollisionToggler7"]
 shape = SubResource("SegmentShape2D_nsedx")


### PR DESCRIPTION
Changes:
- Created 8 track
- Added collision and z index toggler object
- Able to create tracks with segments instead of polygons (which are closed)